### PR TITLE
Adjusted Tailwind Configuration to match color theme from style guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next-auth": "^4.10.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^4.4.0",
         "react-query": "^3.39.2",
         "superjson": "^1.9.1",
         "zod": "^3.17.3"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next-auth": "^4.10.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.4.0",
     "react-query": "^3.39.2",
     "superjson": "^1.9.1",
     "zod": "^3.17.3"

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,15 +1,63 @@
 /** @type {import('tailwindcss').Config} */
+
+const colors = require('tailwindcss/colors');
 module.exports = {
   content: [
-    "./node_modules/flowbite-react/**/*.js",
-    "./src/**/*.{js,ts,jsx,tsx}",
-    "./src/pages/**/*.{ts,tsx}",
-    "./public/**/*.html"
+    './node_modules/flowbite-react/**/*.js',
+    './src/**/*.{js,ts,jsx,tsx}',
+    './src/pages/**/*.{ts,tsx}',
+    './public/**/*.html',
   ],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        // primary is now alias for green color palette
+        primary: colors.green,
+        // dark is now alias for gray color palette
+        dark: colors.gray,
+
+        // override green color palette
+        // 'success' green will now be mapped to green configuration here
+        green: {
+          200: '#f2fef7',
+          300: '#e6fdef',
+          400: '#bffbd7',
+          500: '#99f8bf',
+          600: '#4df28f',
+          700: '#00ed5f',
+          800: '#00d556',
+          900: '#00b247',
+          DEFAULT: '#00ed5f', //700
+        },
+
+        // create new color palette with alias of secondary
+        // corresponds to dark green from style guide
+        secondary: {
+          200: '#f4f6f5',
+          300: '#eaedeb',
+          400: '#c9d3cd',
+          500: '#a9b9af',
+          600: '#698473',
+          700: '#284f37',
+          800: '#244732',
+          900: '#1e3b29',
+          DEFAULT: '#284f37', //700
+        },
+
+        // override gray color palette
+        // 'dark' gray will now be mapped to gray configuration here
+        gray: {
+          300: '#f4f4f4',
+          400: '#e9e9e9',
+          500: '#c7c7c7',
+          600: '#a5a5a5',
+          700: '#626262',
+          800: '#1e1e1e',
+          900: '#1b1b1b',
+          DEFAULT: '#1e1e1e', //700
+        },
+      },
+    },
   },
-  plugins: [
-    require("flowbite/plugin")
-  ]
+  plugins: [require('flowbite/plugin')],
 };


### PR DESCRIPTION
- Added color themes to the tailwind configuration to match up with the style guide as well as be usable with the Flowbite-React components. 
  - This will allow use of classes like `bg-primary`, `bg-secondary` and `bg-dark` that correspond with 'lime green', 'dark green' and 'dark gray' from the style guide, respectively.
  - For Flowbite-React components utilizing `color='success'` and `color='dark'`, should achieve similar results as above for the 'lime green' and 'dark gray' colors from the style guide, respectively.
  
- Added react-icons package

Closes #60 