### PR TITLE
Bug/navbar

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -37,7 +37,7 @@ const Nav = () => {
           {/* MOBILE BUTTON */}
           <div
             onClick={handleNav}
-            className="sm:hidden block z-10 text-green cursor-pointer"
+            className="sm:hidden block z-[100] text-green cursor-pointer"
           >
             {nav ? <MdClose size={20} /> : <HiMenuAlt3 size={20} />}
           </div>
@@ -46,8 +46,8 @@ const Nav = () => {
         <div
           className={
             nav
-              ? `sm:hidden absolute top-0 left-0 right-0 bottom-0 flex justify-center items-center w-full h-screen bg-gray text-center text-white ease-in duration-300`
-              : `sm:hidden absolute top-0 left-[-100%] right-0 bottom-0 flex justify-center items-center w-full h-screen bg-gray text-center text-white ease-in duration-300`
+              ? `sm:hidden absolute top-0 left-0 right-0 bottom-0 flex justify-center items-center w-full h-screen bg-gray text-center text-white ease-in duration-300 z-50`
+              : `sm:hidden absolute top-0 left-[-100%] right-0 bottom-0 flex justify-center items-center w-full h-screen bg-gray text-center text-white ease-in duration-300 z-50`
           }
         >
           <ul>

--- a/src/pages/travel.tsx
+++ b/src/pages/travel.tsx
@@ -17,8 +17,8 @@ export default function TravelPage() {
         <Link href="/">Home</Link>
       </nav>
 
-      <div className='flex justify-center'>
-        <Image src={wateringPlantsImage} alt='person watering plant'/>
+      <div className="flex justify-center">
+        <Image src={wateringPlantsImage} alt="person watering plant" />
       </div>
 
       <div className="mx-auto flex justify-center w-1/3">


### PR DESCRIPTION
fixed the z indexes to show over the page content. Should work across all devices now

**NOTE**
Came across two bugs which will need future fixing: 

- Responsiveness of 'tabs' and the top content on the /travel page on mobile devices
- When mobile nav is showing; longer pages will display the rest of it's content underneath the menu